### PR TITLE
Search in editor: disable smart search

### DIFF
--- a/app/templates/editor.html
+++ b/app/templates/editor.html
@@ -186,6 +186,10 @@
             dom: "<'row m-1'<'col-auto'B><'col-auto ms-auto'f><'col-auto'l>>" +
                 "<'row'<'col-12'tr>>" +
                 "<'row mb-1 mb-lg-0'<'col-auto text-light'i><'col-auto ms-auto'p>>",
+            search: {
+                return: true,
+                smart: false,
+            },
             orderFixed: [0, 'des'],
             order: [[0, 'des'], [2, 'asc']],
             pageLength: 25,


### PR DESCRIPTION
And initiate the search after presing Enter.
This seems more suitable for performance, as well for using regex, search builder