### PR TITLE
Modify stb.getUrl to retun fast, already "deep" url, or to discover and return a deep one. 

### DIFF
--- a/app/stb.py
+++ b/app/stb.py
@@ -27,6 +27,9 @@ def getUrl(url, proxy=None):
         )
         return portal
 
+    if url.endswith(".php"):
+        return url
+
     url = urlparse(url).scheme + "://" + urlparse(url).netloc
     urls = [
         "/c/xpcom.common.js",


### PR DESCRIPTION
This allow to invoke stb.getUrl anytime before passing url (which has to be the deep one) to other function.
Potential use case is when adding new portal to check (deep url is needed) the validity of macs.